### PR TITLE
Upgrade build method, docker base images, and fix tz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,19 @@
 #   Build Service & Dependencies
 #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-FROM veupathdb/alpine-dev-base:jdk-15 AS prep
+FROM veupathdb/alpine-dev-base:jdk-18 AS prep
 
 LABEL service="site-search-build"
+
+ARG GITHUB_USERNAME
+ARG GITHUB_TOKEN
 
 WORKDIR /workspace
 
 RUN jlink --compress=2 --module-path /opt/jdk/jmods \
        --add-modules java.base,java.net.http,java.security.jgss,java.logging,java.xml,java.desktop,java.management,java.sql,java.naming \
        --output /jlinked \
-    && apk add --no-cache git sed findutils coreutils make npm curl maven bash \
+    && apk add --no-cache git sed findutils coreutils make npm curl gawk jq \
     && git config --global advice.detachedHead false
 
 ENV DOCKER=build
@@ -26,7 +29,7 @@ RUN make jar
 #   Run the service
 #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-FROM foxcapades/alpine-oracle:1.3
+FROM alpine:3.16
 
 LABEL service="site-search"
 

--- a/makefile
+++ b/makefile
@@ -18,16 +18,12 @@ default:
 	@echo ""
 
 .PHONY: jar
-jar: fgputil
-	mvn clean package
-
-.PHONY: fgputil
-fgputil:
-	bash bin/build-fgputil.sh
+jar:
+	mvn clean package --settings ./settings.xml
 
 .PHONY: docker
 docker:
-	docker build --no-cache -t site-search .
+	docker build --no-cache -t site-search . --build-arg GITHUB_USERNAME=${GITHUB_USERNAME} --build-arg GITHUB_TOKEN=${GITHUB_TOKEN}
 
 .PHONY: clean
 clean:

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <name>Site Search Service</name>
@@ -10,19 +12,73 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>base-pom</artifactId>
-    <version>1.0.0</version>
-    <relativePath>.build/FgpUtil/Dependencies/org/gusdb/base-pom/1.0.0/base-pom-1.0.0.pom</relativePath>
+    <version>2.13</version>
   </parent>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <fgputil.version>2.9.1</fgputil.version>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.gusdb</groupId>
+      <artifactId>fgputil-core</artifactId>
+      <version>${fgputil.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.gusdb</groupId>
+      <artifactId>fgputil-solr</artifactId>
+      <version>${fgputil.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.gusdb</groupId>
+      <artifactId>fgputil-json</artifactId>
+      <version>${fgputil.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.gusdb</groupId>
+      <artifactId>fgputil-web</artifactId>
+      <version>${fgputil.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.gusdb</groupId>
+      <artifactId>fgputil-server</artifactId>
+      <version>${fgputil.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
 
   <repositories>
     <repository>
-      <id>eupathdb</id>
-      <name>EuPathDB Project Dependencies</name>
-      <layout>default</layout>
-      <url>https://raw.githubusercontent.com/VEuPathDB/FgpUtil/master/Dependencies/</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
+      <id>veupathdb</id>
+      <url>https://maven.pkg.github.com/VEuPathDB/maven-packages</url>
     </repository>
   </repositories>
 
@@ -63,61 +119,6 @@
       </plugin>
     </plugins>
   </build>
-
-  <dependencies>
-
-    <dependency>
-      <groupId>org.gusdb</groupId>
-      <artifactId>fgputil-core</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.gusdb</groupId>
-      <artifactId>fgputil-solr</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.gusdb</groupId>
-      <artifactId>fgputil-json</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.gusdb</groupId>
-      <artifactId>fgputil-web</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.gusdb</groupId>
-      <artifactId>fgputil-server</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.json</groupId>
-      <artifactId>json</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.glassfish.jersey.core</groupId>
-      <artifactId>jersey-client</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-  </dependencies>
 
 </project>
  

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,12 @@
+<settings
+    xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>veupathdb</id>
+      <username>${env.GITHUB_USERNAME}</username>
+      <password>${env.GITHUB_TOKEN}</password>
+    </server>
+  </servers>
+</settings>


### PR DESCRIPTION
Change tz method was just a matter of copying over how we do it on other services, but to get that to work required base image upgrades.  In addition, docker build was not failing after the changes to how FgpUtil builds.  Rather than fix the FgpUtil build, I changed this project to use released FgpUtil libs like all other projects.