### PR TITLE
New endpoint that reports on installed cores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 target
 *~
 \#*
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
   orthosearch:
     image: veupathdb/site-search:${SITESEARCH_TAG:-latest}
     environment:
-      SOLR_URL: http://solr:${SOLR_PORT:-8983}/solr/orthosearch
+      SOLR_URL: http://${SOLR_URL:-solr}:${SOLR_PORT:-8983}/solr
+      SOLR_CORE: orthosearch
     networks:
       - internal
       - traefik
@@ -21,7 +22,8 @@ services:
   edasearch:
     image: veupathdb/site-search:${SITESEARCH_TAG:-latest}
     environment:
-      SOLR_URL: http://solr:${SOLR_PORT:-8983}/solr/edasearch
+      SOLR_URL: http://${SOLR_URL:-solr}:${SOLR_PORT:-8983}/solr
+      SOLR_CORE: edasearch
     networks:
       - internal
       - traefik
@@ -35,7 +37,8 @@ services:
   sitesearch:
     image: veupathdb/site-search:${SITESEARCH_TAG:-latest}
     environment:
-      SOLR_URL: http://solr:${SOLR_PORT:-8983}/solr/site_search
+      SOLR_URL: http://${SOLR_URL:-solr}:${SOLR_PORT:-8983}/solr
+      SOLR_CORE: site_search
     networks:
       - internal
       - traefik

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   orthosearch:
     image: veupathdb/site-search:${SITESEARCH_TAG:-latest}
     environment:
-      SOLR_URL: http://${SOLR_URL:-solr}:${SOLR_PORT:-8983}/solr
+      SOLR_URL: http://solr:${SOLR_PORT:-8983}/solr
       SOLR_CORE: orthosearch
     networks:
       - internal
@@ -22,7 +22,7 @@ services:
   edasearch:
     image: veupathdb/site-search:${SITESEARCH_TAG:-latest}
     environment:
-      SOLR_URL: http://${SOLR_URL:-solr}:${SOLR_PORT:-8983}/solr
+      SOLR_URL: http://solr:${SOLR_PORT:-8983}/solr
       SOLR_CORE: edasearch
     networks:
       - internal
@@ -37,7 +37,7 @@ services:
   sitesearch:
     image: veupathdb/site-search:${SITESEARCH_TAG:-latest}
     environment:
-      SOLR_URL: http://${SOLR_URL:-solr}:${SOLR_PORT:-8983}/solr
+      SOLR_URL: http://solr:${SOLR_PORT:-8983}/solr
       SOLR_CORE: site_search
     networks:
       - internal

--- a/pom.xml
+++ b/pom.xml
@@ -12,12 +12,12 @@
   <parent>
     <groupId>org.gusdb</groupId>
     <artifactId>base-pom</artifactId>
-    <version>2.13</version>
+    <version>2.16</version>
   </parent>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <fgputil.version>2.9.3</fgputil.version>
+    <fgputil.version>2.12.11</fgputil.version>
   </properties>
 
   <dependencies>
@@ -133,4 +133,4 @@
   </build>
 
 </project>
- 
+

--- a/src/main/java/org/gusdb/sitesearch/service/server/Server.java
+++ b/src/main/java/org/gusdb/sitesearch/service/server/Server.java
@@ -46,12 +46,14 @@ public class Server extends RESTServer {
   public static class Context extends BasicApplicationContext {
 
     public static final String SOLR_URL = "SOLR_URL";
+    public static final String SOLR_CORE = "SOLR_CORE";
 
     /**
      * @param config unused config; now performed by env vars
      */
     public Context(JSONObject config) {
       put(SOLR_URL, Environment.getRequiredVar(SOLR_URL));
+      put(SOLR_CORE, Environment.getRequiredVar(SOLR_CORE));
     }
 
     @Override


### PR DESCRIPTION
### Description

This PR updates the site search service by adding a new endpoint that spits out details about the cores installed in the backing SOLR instance.  This is to support requested features in the future admin dashboard.

### Changes

* Split SOLR_URL environment variable into 2 components to allow accessing non-query SOLR endpoints.
* Update dependencies (to try and resolve issues with JVM version compatibility)
* Add new endpoint that pipes the `/admin/cores` endpoint data from SOLR to the requesting client.